### PR TITLE
Use 1.13 way again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@
         <!-- NMS -->
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-1.14</artifactId>
-            <version>1.14</version>
+            <artifactId>spigot-1.14.1</artifactId>
+            <version>1.14.1</version>
             <systemPath>${spigot.jars}/spigot-1.14.1.jar</systemPath>
             <scope>system</scope>
         </dependency>

--- a/src/main/java/de/False/BuildersWand/events/WandStorageEvents.java
+++ b/src/main/java/de/False/BuildersWand/events/WandStorageEvents.java
@@ -70,7 +70,7 @@ public class WandStorageEvents implements Listener
         }
 
         ItemStack[] inventoryContent = inventoryManager.getInventory(uuid);
-        Inventory storage = Bukkit.createInventory(player, wand.getInventorySize(), INVENTORY_NAME);
+        Inventory storage = Bukkit.createInventory(new BWHolder(player), wand.getInventorySize(), INVENTORY_NAME);
         storage.setContents(inventoryContent);
         player.openInventory(storage);
     }
@@ -81,7 +81,7 @@ public class WandStorageEvents implements Listener
         Player player = event.getPlayer();
         InventoryView openInventory = player.getOpenInventory();
         Inventory storage = openInventory.getTopInventory();
-        if(storage == null)
+        if(storage == null || !(storage.getHolder() instanceof BWHolder))
         {
             return;
         }
@@ -101,7 +101,7 @@ public class WandStorageEvents implements Listener
     {
         Player player = (Player) event.getWhoClicked();
         Inventory storage = event.getInventory();
-        if(storage == null)
+        if(storage == null || !(storage.getHolder() instanceof BWHolder))
         {
             return;
         }
@@ -121,13 +121,15 @@ public class WandStorageEvents implements Listener
         Inventory storage = event.getInventory();
         ItemStack itemStack = event.getCurrentItem();
         InventoryAction action = event.getAction();
-        if((action == InventoryAction.HOTBAR_SWAP || action == InventoryAction.HOTBAR_MOVE_AND_READD))
+        if((action == InventoryAction.HOTBAR_SWAP || action == InventoryAction.HOTBAR_MOVE_AND_READD) &&
+                storage.getHolder() instanceof BWHolder)
         {
             event.setCancelled(true);
         }
 
         if(
                 storage == null
+                || !(storage.getHolder() instanceof BWHolder)
                 || itemStack == null
                 || itemStack.getType().isBlock()
         )
@@ -144,7 +146,7 @@ public class WandStorageEvents implements Listener
         Player player = (Player) event.getPlayer();
         Inventory storage = event.getInventory();
         ItemStack mainHand = nms.getItemInHand(player);
-        if(mainHand == null || mainHand.getType() == Material.AIR || storage == null)
+        if(mainHand == null || mainHand.getType() == Material.AIR || storage == null || !(storage.getHolder() instanceof BWHolder))
         {
             return;
         }

--- a/src/main/java/de/False/BuildersWand/inventory/BWHolder.java
+++ b/src/main/java/de/False/BuildersWand/inventory/BWHolder.java
@@ -1,11 +1,17 @@
 package de.False.BuildersWand.inventory;
 
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
 public class BWHolder implements InventoryHolder {
 
 	private Inventory inventory;
+	private Player player;
+
+	public BWHolder(Player player) {
+		this.player = player;
+	}
 
 	public void setInventory(Inventory inventory) {
 		this.inventory = inventory;
@@ -13,6 +19,10 @@ public class BWHolder implements InventoryHolder {
 
 	public Inventory getInventory() {
 		return inventory;
+	}
+
+	public Player getPlayer() {
+		return player;
 	}
 
 }


### PR DESCRIPTION
I don't know, if this works, but your last commit made using the normal inventory very unsafe, so you should think about this again.
The thing I was missing, was the ``new BWHolder(player)`` here: https://github.com/ThexXTURBOXx/Builder-s-Wand/blob/f8f3b03f91face209180f8a91784bf51e93d1fc8/src/main/java/de/False/BuildersWand/events/WandStorageEvents.java#L73
That's most likely, why the storage was broken. If it still doesn't work with this commit, try to fix it again, but I wouldn't remove the if cases in the WandStorageEvents class