### PR TITLE
Fixed WorldGuard 6 and 7 compat in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,14 @@
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-legacy</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
+            <version>6.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -102,6 +109,12 @@
             <groupId>com.github.TechFortress</groupId>
             <artifactId>GriefPrevention</artifactId>
             <version>16.7.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sk89q</groupId>
+                    <artifactId>worldguard</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Add this yourself to your local Maven repo! -->


### PR DESCRIPTION
_This PR **only** fixes the POM, not any of the java files!_
For #28 
So, basically, this is it.
If you want, you can change the WorldGuard dependency to version 7.0.0, which the offical release, but I would stay with SNAPSHOT 7.0.1.
The exclusion is to prevent a second Worldguard dependency in the tree.